### PR TITLE
Vignette improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggpattern
 Type: Package
 Title: 'ggplot2' Pattern Geoms
-Version: 1.1.0-6
+Version: 1.1.0-7
 Authors@R: c(person("Mike", "FC", role = "aut"),
              person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,17 +12,9 @@ knitr::opts_chunk$set(
   out.width = "100%"
 )
 
-library(ggplot2)
-library(dplyr)
-library(ggpattern)
-
-
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Generate the pkgdown documentation
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-if (FALSE) {
-  pkgdown::build_site(override = list(destination = "../coolbutuseless.github.io/package/ggpattern"))
-}
+library("dplyr")
+library("ggplot2")
+library("ggpattern")
 
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,13 +47,13 @@ if (FALSE) {
 <!-- badges: start -->
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/ggpattern)](https://cran.r-project.org/package=ggpattern)
 ![](http://img.shields.io/badge/cool-useless-green.svg)
-[![R build status](https://github.com/coolbutuseless/ggpattern/workflows/R-CMD-check/badge.svg)](https://github.com/coolbutuseless/ggpattern/actions)
+[![R build status](https://github.com/trevorld/ggpattern/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/ggpattern/actions)
 <!-- badges: end -->
 
 <span style="font-size: xx-large; font-weight: normal;">`ggpattern` provides custom `ggplot2` geoms which support filled areas with 
 geometric and image-based patterns.</span>
 
-Reading the articles/vignettes on [the package website](https://coolbutuseless.github.io/package/ggpattern/) is 
+Reading the articles/vignettes on [the package website](https://trevorldavis.com/R/ggpattern/dev/) is
 probably the best way to get started.
 
 
@@ -74,11 +66,11 @@ probably the best way to get started.
 
 ## Installation
 
-You can install the development version from [GitHub](https://github.com/coolbutuseless/ggpattern) with the following instructions:
+You can install the development version from [GitHub](https://github.com/trevorld/ggpattern) with the following instructions:
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("coolbutuseless/ggpattern")
+remotes::install_github("trevorld/ggpattern")
 ```
 
 You can install the CRAN release version using:
@@ -122,14 +114,14 @@ ggplot(df) +
 # Gallery
 
 <div>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-bar-pattern-"><img width="45%" src="man/figures/readme/gallery-bar-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#b-w-example"><img width="45%" src="man/figures/readme/gallery-bar-bw.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#colour-example-1"><img width="45%" src="man/figures/readme/gallery-bar-colour.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-bar-pattern-coord-flip-and-fit-image-to-height-and-graivty-towards-the-east-"><img width="45%" src="man/figures/readme/gallery-bar2-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-grid.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-map-pattern-"><img width="45%" src="man/figures/readme/gallery-map-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-rect-pattern-"><img width="45%" src="man/figures/readme/gallery-rect-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-bar-pattern-"><img width="45%" src="man/figures/readme/gallery-bar-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#b-w-example"><img width="45%" src="man/figures/readme/gallery-bar-bw.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#colour-example-1"><img width="45%" src="man/figures/readme/gallery-bar-colour.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-bar-pattern-coord-flip-and-fit-image-to-height-and-graivty-towards-the-east-"><img width="45%" src="man/figures/readme/gallery-bar2-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-grid.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-map-pattern-"><img width="45%" src="man/figures/readme/gallery-map-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-rect-pattern-"><img width="45%" src="man/figures/readme/gallery-rect-array.jpg" /> </a>
 <div>
 
 
@@ -143,8 +135,8 @@ ggplot(df) +
 support being filled with a pattern.
 
 See the vignette galleries for examples of all the available geoms filled with 
-[geometry-based patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html) and 
-[image-based/array-based patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html).
+[geometry-based patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html) and 
+[image-based/array-based patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html).
 
 
 <details>
@@ -181,7 +173,7 @@ There are also scale functions to control each of these new aesthetics e.g.
 
 Not all aesthetics apply to all patterns.  See the individual pattern vignettes
 for which aesthetics it uses, or see the first vignette on developing user-defined
-patterns for a [table of aesthetic use by pattern](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns-1.html#aes-by-pattern),
+patterns for a [table of aesthetic use by pattern](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns-1.html#aes-by-pattern),
 or see the individual vignettes for each pattern.
 
 <details>
@@ -226,7 +218,7 @@ or see the individual vignettes for each pattern.
 Users can write their own pattern functions and ask `ggpattern` to use them, 
 without having to include the pattern in the package.
 
-See the vignette on developing patterns: [`vignette("developing-patterns", package = "ggpattern")`](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns.html).
+See the vignette on developing patterns: [`vignette("developing-patterns", package = "ggpattern")`](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns.html).
 
 # Vignettes
 
@@ -234,27 +226,27 @@ See the vignette on developing patterns: [`vignette("developing-patterns", packa
 
 #### General examples
 
-* [Examples of every geom filled with the geometry-based patterns (i.e. 'stripe', 'crosshatch', 'circle')](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
-* [Examples of every geom filled with the array-based patterns (i.e. 'image', 'magick', 'gradient', 'plasma', 'placeholder')](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
+* [Examples of every geom filled with the geometry-based patterns (i.e. 'stripe', 'crosshatch', 'circle')](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
+* [Examples of every geom filled with the array-based patterns (i.e. 'image', 'magick', 'gradient', 'plasma', 'placeholder')](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
 
 #### Exploration of pattern parameters and appearance
 
-* [Patterns 'circle', 'pch', 'regular_polygon', 'rose' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-points.html): `vignette("patterns-points", package = "ggpattern")`
-* [Patterns 'gradient', 'ambient', 'plasma' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-noise.html): `vignette("patterns-noise", package = "ggpattern")`
-* [Patterns 'image' and 'placeholder' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-image.html): `vignette("patterns-image", package = "ggpattern")`
-* [Patterns 'magick' and 'polygon_tiling' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-tilings.html): `vignette("patterns-tilings", package = "ggpattern")`
-* [Patterns 'stripe', 'wave', 'crosshatch', 'weave' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-stripes.html): `vignette("patterns-stripes", package = "ggpattern")`
+* [Patterns 'circle', 'pch', 'regular_polygon', 'rose' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-points.html): `vignette("patterns-points", package = "ggpattern")`
+* [Patterns 'gradient', 'ambient', 'plasma' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-noise.html): `vignette("patterns-noise", package = "ggpattern")`
+* [Patterns 'image' and 'placeholder' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-image.html): `vignette("patterns-image", package = "ggpattern")`
+* [Patterns 'magick' and 'polygon_tiling' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-tilings.html): `vignette("patterns-tilings", package = "ggpattern")`
+* [Patterns 'stripe', 'wave', 'crosshatch', 'weave' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-stripes.html): `vignette("patterns-stripes", package = "ggpattern")`
 
-* [Parameters for Geometry-based Patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geometry-based-pattern-parameters.html): `vignette("geometry-based-pattern-parameters", package = "ggpattern")`
+* [Parameters for Geometry-based Patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geometry-based-pattern-parameters.html): `vignette("geometry-based-pattern-parameters", package = "ggpattern")`
 
 #### Developing your own pattern
 
-* [Developing Patterns](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns.html): `vignette("developing-patterns", package = "ggpattern")`
+* [Developing Patterns](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns.html): `vignette("developing-patterns", package = "ggpattern")`
 
 #### Other examples
 
-* [Animating Patterns with `{gganimate}`](https://coolbutuseless.github.io/package/ggpattern/articles/gganimate.html): `vignette("gganimate", package = "ggpattern")`
-* [Creating the Logo in R](https://coolbutuseless.github.io/package/ggpattern/articles/create-logo.html): `vignette("create-logo", package = "ggpattern")`
+* [Animating Patterns with `{gganimate}`](https://trevorldavis.com/R/ggpattern/dev/articles/gganimate.html): `vignette("gganimate", package = "ggpattern")`
+* [Creating the Logo in R](https://trevorldavis.com/R/ggpattern/dev/articles/create-logo.html): `vignette("create-logo", package = "ggpattern")`
 
 # Limitations
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ output: github_document
 <!-- badges: start -->
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/ggpattern)](https://cran.r-project.org/package=ggpattern)
 ![](http://img.shields.io/badge/cool-useless-green.svg)
-[![R build status](https://github.com/coolbutuseless/ggpattern/workflows/R-CMD-check/badge.svg)](https://github.com/coolbutuseless/ggpattern/actions)
+[![R build status](https://github.com/trevorld/ggpattern/workflows/R-CMD-check/badge.svg)](https://github.com/trevorld/ggpattern/actions)
 <!-- badges: end -->
 
 <span style="font-size: xx-large; font-weight: normal;">`ggpattern` provides custom `ggplot2` geoms which support filled areas with 
 geometric and image-based patterns.</span>
 
-Reading the articles/vignettes on [the package website](https://coolbutuseless.github.io/package/ggpattern/) is 
+Reading the articles/vignettes on [the package website](https://trevorldavis.com/R/ggpattern/dev/) is
 probably the best way to get started.
 
 
@@ -30,11 +30,11 @@ probably the best way to get started.
 
 ## Installation
 
-You can install the development version from [GitHub](https://github.com/coolbutuseless/ggpattern) with the following instructions:
+You can install the development version from [GitHub](https://github.com/trevorld/ggpattern) with the following instructions:
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("coolbutuseless/ggpattern")
+remotes::install_github("trevorld/ggpattern")
 ```
 
 You can install the CRAN release version using:
@@ -81,14 +81,14 @@ ggplot(df) +
 # Gallery
 
 <div>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-bar-pattern-"><img width="45%" src="man/figures/readme/gallery-bar-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#b-w-example"><img width="45%" src="man/figures/readme/gallery-bar-bw.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#colour-example-1"><img width="45%" src="man/figures/readme/gallery-bar-colour.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-bar-pattern-coord-flip-and-fit-image-to-height-and-graivty-towards-the-east-"><img width="45%" src="man/figures/readme/gallery-bar2-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-grid.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-map-pattern-"><img width="45%" src="man/figures/readme/gallery-map-array.jpg" /> </a>
-<a href="https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html#geom-rect-pattern-"><img width="45%" src="man/figures/readme/gallery-rect-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-bar-pattern-"><img width="45%" src="man/figures/readme/gallery-bar-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#b-w-example"><img width="45%" src="man/figures/readme/gallery-bar-bw.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#colour-example-1"><img width="45%" src="man/figures/readme/gallery-bar-colour.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-bar-pattern-coord-flip-and-fit-image-to-height-and-graivty-towards-the-east-"><img width="45%" src="man/figures/readme/gallery-bar2-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html#geom-density-pattern-"><img width="45%" src="man/figures/readme/gallery-density-grid.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-map-pattern-"><img width="45%" src="man/figures/readme/gallery-map-array.jpg" /> </a>
+<a href="https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html#geom-rect-pattern-"><img width="45%" src="man/figures/readme/gallery-rect-array.jpg" /> </a>
 <div>
 
 
@@ -102,8 +102,8 @@ ggplot(df) +
 support being filled with a pattern.
 
 See the vignette galleries for examples of all the available geoms filled with 
-[geometry-based patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html) and 
-[image-based/array-based patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html).
+[geometry-based patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html) and 
+[image-based/array-based patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html).
 
 
 <details>
@@ -140,7 +140,7 @@ There are also scale functions to control each of these new aesthetics e.g.
 
 Not all aesthetics apply to all patterns.  See the individual pattern vignettes
 for which aesthetics it uses, or see the first vignette on developing user-defined
-patterns for a [table of aesthetic use by pattern](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns-1.html#aes-by-pattern),
+patterns for a [table of aesthetic use by pattern](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns-1.html#aes-by-pattern),
 or see the individual vignettes for each pattern.
 
 <details>
@@ -185,7 +185,7 @@ or see the individual vignettes for each pattern.
 Users can write their own pattern functions and ask `ggpattern` to use them, 
 without having to include the pattern in the package.
 
-See the vignette on developing patterns: [`vignette("developing-patterns", package = "ggpattern")`](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns.html).
+See the vignette on developing patterns: [`vignette("developing-patterns", package = "ggpattern")`](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns.html).
 
 # Vignettes
 
@@ -193,27 +193,27 @@ See the vignette on developing patterns: [`vignette("developing-patterns", packa
 
 #### General examples
 
-* [Examples of every geom filled with the geometry-based patterns (i.e. 'stripe', 'crosshatch', 'circle')](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-geometry.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
-* [Examples of every geom filled with the array-based patterns (i.e. 'image', 'magick', 'gradient', 'plasma', 'placeholder')](https://coolbutuseless.github.io/package/ggpattern/articles/geom-gallery-array.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
+* [Examples of every geom filled with the geometry-based patterns (i.e. 'stripe', 'crosshatch', 'circle')](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-geometry.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
+* [Examples of every geom filled with the array-based patterns (i.e. 'image', 'magick', 'gradient', 'plasma', 'placeholder')](https://trevorldavis.com/R/ggpattern/dev/articles/geom-gallery-array.html): `vignette("geom-gallery-geometry", package = "ggpattern")`
 
 #### Exploration of pattern parameters and appearance
 
-* [Patterns 'circle', 'pch', 'regular_polygon', 'rose' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-points.html): `vignette("patterns-points", package = "ggpattern")`
-* [Patterns 'gradient', 'ambient', 'plasma' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-noise.html): `vignette("patterns-noise", package = "ggpattern")`
-* [Patterns 'image' and 'placeholder' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-image.html): `vignette("patterns-image", package = "ggpattern")`
-* [Patterns 'magick' and 'polygon_tiling' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-tilings.html): `vignette("patterns-tilings", package = "ggpattern")`
-* [Patterns 'stripe', 'wave', 'crosshatch', 'weave' - Parameters and Examples](https://coolbutuseless.github.io/package/ggpattern/articles/patterns-stripes.html): `vignette("patterns-stripes", package = "ggpattern")`
+* [Patterns 'circle', 'pch', 'regular_polygon', 'rose' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-points.html): `vignette("patterns-points", package = "ggpattern")`
+* [Patterns 'gradient', 'ambient', 'plasma' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-noise.html): `vignette("patterns-noise", package = "ggpattern")`
+* [Patterns 'image' and 'placeholder' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-image.html): `vignette("patterns-image", package = "ggpattern")`
+* [Patterns 'magick' and 'polygon_tiling' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-tilings.html): `vignette("patterns-tilings", package = "ggpattern")`
+* [Patterns 'stripe', 'wave', 'crosshatch', 'weave' - Parameters and Examples](https://trevorldavis.com/R/ggpattern/dev/articles/patterns-stripes.html): `vignette("patterns-stripes", package = "ggpattern")`
 
-* [Parameters for Geometry-based Patterns](https://coolbutuseless.github.io/package/ggpattern/articles/geometry-based-pattern-parameters.html): `vignette("geometry-based-pattern-parameters", package = "ggpattern")`
+* [Parameters for Geometry-based Patterns](https://trevorldavis.com/R/ggpattern/dev/articles/geometry-based-pattern-parameters.html): `vignette("geometry-based-pattern-parameters", package = "ggpattern")`
 
 #### Developing your own pattern
 
-* [Developing Patterns](https://coolbutuseless.github.io/package/ggpattern/articles/developing-patterns.html): `vignette("developing-patterns", package = "ggpattern")`
+* [Developing Patterns](https://trevorldavis.com/R/ggpattern/dev/articles/developing-patterns.html): `vignette("developing-patterns", package = "ggpattern")`
 
 #### Other examples
 
-* [Animating Patterns with `{gganimate}`](https://coolbutuseless.github.io/package/ggpattern/articles/gganimate.html): `vignette("gganimate", package = "ggpattern")`
-* [Creating the Logo in R](https://coolbutuseless.github.io/package/ggpattern/articles/create-logo.html): `vignette("create-logo", package = "ggpattern")`
+* [Animating Patterns with `{gganimate}`](https://trevorldavis.com/R/ggpattern/dev/articles/gganimate.html): `vignette("gganimate", package = "ggpattern")`
+* [Creating the Logo in R](https://trevorldavis.com/R/ggpattern/dev/articles/create-logo.html): `vignette("create-logo", package = "ggpattern")`
 
 # Limitations
 

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,2 +1,3 @@
 *.html
 *.R
+images/*.gif

--- a/vignettes/geom-gallery-array.Rmd
+++ b/vignettes/geom-gallery-array.Rmd
@@ -11,8 +11,12 @@ vignette: >
 
 ```r
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("dplyr", quietly = TRUE)
+  require("magick", quietly = TRUE)
+  require("maps", quietly = TRUE)
+  require("sf", quietly = TRUE)
 })
 ```
 
@@ -21,38 +25,28 @@ suppressPackageStartupMessages({
 
 ```r
 if (require("magick")) {
-
 p <- ggplot(mpg, aes(class)) +
   geom_bar_pattern(
     aes(
-      pattern_angle = class
+      pattern_fill = class
     ), 
-    pattern         = 'placeholder',
-    pattern_type    = 'kitten',
-    fill            = 'white', 
+    pattern         = 'plasma',
     colour          = 'black',
-    pattern_spacing = 0.025
   ) +
   theme_bw(18) +
   labs(
     title = "ggpattern::geom_bar_pattern()",
-    subtitle = "pattern = 'placeholder', pattern_type = 'kitten'"
+    subtitle = "pattern = 'plasma'"
   ) + 
   theme(legend.position = 'none') +
   coord_fixed(ratio = 1/15) + 
   scale_pattern_discrete(guide = guide_legend(nrow = 1))
 
 p
-
 }
-#> Loading required package: magick
-#> Linking to ImageMagick 6.9.10.23
-#> Enabled features: fontconfig, freetype, fftw, lcms, pango, webp, x11
-#> Disabled features: cairo, ghostscript, heic, raw, rsvg
-#> Using 8 threads
 ```
 
-![plot of chunk bar](images/gallery-array-bar-1.png)
+![](images/gallery-array-bar-1.png)
 
 ## `geom_bar_pattern()` - fit image to width and tile.
 
@@ -97,7 +91,7 @@ p
 }
 ```
 
-![plot of chunk bar2](images/gallery-array-bar2-1.png)
+![](images/gallery-array-bar2-1.png)
 
 ## `geom_bar_pattern()` + `coord_flip` and fit image to height and graivty towards the east.
 
@@ -133,7 +127,7 @@ p
 }
 ```
 
-![plot of chunk bar3](images/gallery-array-bar3-1.png)
+![](images/gallery-array-bar3-1.png)
 
 ## pie graph with `geom_bar_pattern()`
 
@@ -176,7 +170,7 @@ p
 }
 ```
 
-![plot of chunk pie](images/gallery-array-pie-1.png)
+![](images/gallery-array-pie-1.png)
 
 ## `geom_bin2d_pattern()`
 
@@ -187,14 +181,14 @@ if (require("magick")) {
 p <- ggplot(diamonds, aes(x, y)) + 
   xlim(4, 10) + ylim(4, 10) +
   geom_bin2d_pattern(
-    aes(pattern_type = ..density..), 
+    aes(pattern_type = after_stat(density)), 
     pattern       = 'magick',
     pattern_scale = 3,
     pattern_fill  = 'black',
     bins          = 6, 
     fill          = 'white', 
     colour        = 'black', 
-    size          = 0.5
+    linewidth     = 0.5
   ) +
   theme_bw(18) +
   theme(legend.position = 'none') + 
@@ -207,10 +201,11 @@ p <- ggplot(diamonds, aes(x, y)) +
 p
 
 }
-#> Warning: Removed 478 rows containing non-finite values (stat_bin2d).
+#> Warning: Removed 478 rows containing non-finite outside the scale range
+#> (`stat_bin2d()`).
 ```
 
-![plot of chunk bin2d](images/gallery-array-bin2d-1.png)
+![](images/gallery-array-bin2d-1.png)
 ## `geom_boxplot_pattern()`
 
 
@@ -249,15 +244,13 @@ p
 }
 ```
 
-![plot of chunk boxplot](images/gallery-array-boxplot-1.png)
+![](images/gallery-array-boxplot-1.png)
 
 ## `geom_col_pattern()`
 
 
 ```r
 if (require("magick")) {
-try({
-
 df <- data.frame(trt = c("a", "b", "c"), outcome = c(2.3, 1.9, 3.2))
 
 p <- ggplot(df, aes(trt, outcome)) +
@@ -275,11 +268,10 @@ p <- ggplot(df, aes(trt, outcome)) +
   coord_fixed(ratio = 1/2)
 
 p
-
-})
-invisible(NULL)
 }
 ```
+
+![](images/gallery-array-col-1.png)
 
 ## `geom_crossbar_pattern()`
 
@@ -318,7 +310,7 @@ p
 }
 ```
 
-![plot of chunk crossbar](images/gallery-array-crossbar-1.png)
+![](images/gallery-array-crossbar-1.png)
 
 ## `geom_density_pattern()`
 
@@ -355,7 +347,7 @@ p
 }
 ```
 
-![plot of chunk density](images/gallery-array-density-1.png)
+![](images/gallery-array-density-1.png)
 
 ## `geom_map_pattern()`
 
@@ -393,10 +385,9 @@ p <- ggplot(crimes, aes(map_id = state)) +
 p
 
 }
-#> Loading required package: maps
 ```
 
-![plot of chunk map](images/gallery-array-map-1.png)
+![](images/gallery-array-map-1.png)
 
 ## `geom_polygon_pattern()`
 
@@ -429,7 +420,7 @@ p
 }
 ```
 
-![plot of chunk polygon](images/gallery-array-polygon-1.png)
+![](images/gallery-array-polygon-1.png)
 
 ## `geom_rect_pattern()`
 
@@ -474,7 +465,7 @@ p
 }
 ```
 
-![plot of chunk rect](images/gallery-array-rect-1.png)
+![](images/gallery-array-rect-1.png)
 
 ## `geom_ribbon_pattern()`
 
@@ -508,7 +499,7 @@ p
 }
 ```
 
-![plot of chunk ribbon](images/gallery-array-ribbon-1.png)
+![](images/gallery-array-ribbon-1.png)
 
 ## `geom_sf_pattern()`
 
@@ -531,9 +522,7 @@ p <- ggplot(nc) +
     pattern_aspect_ratio = 3
   ) +
   theme_bw(15) + 
-  # theme(legend.key.size = unit(1.5, 'cm')) +
   theme(legend.position = 'none') +
-  scale_pattern_type_discrete(choices = gridpattern::names_magick) + 
   labs(
     title = "ggpattern::geom_sf_pattern()",
     subtitle = "pattern = 'placeholder', pattern_type = 'keanu'"
@@ -542,28 +531,9 @@ p <- ggplot(nc) +
 p
 
 }
-#> Loading required package: dplyr
-#> 
-#> Attaching package: 'dplyr'
-#> The following objects are masked from 'package:stats':
-#> 
-#>     filter, lag
-#> The following objects are masked from 'package:base':
-#> 
-#>     intersect, setdiff, setequal, union
-#> Loading required package: sf
-#> Linking to GEOS 3.8.0, GDAL 3.0.4, PROJ 6.3.1
-#> Warning: ImageMagick was built without librsvg which causes poor qualty of SVG rendering.
-#> For better results use image_read_svg() which uses the rsvg package.
-
-#> Warning: ImageMagick was built without librsvg which causes poor qualty of SVG rendering.
-#> For better results use image_read_svg() which uses the rsvg package.
-
-#> Warning: ImageMagick was built without librsvg which causes poor qualty of SVG rendering.
-#> For better results use image_read_svg() which uses the rsvg package.
 ```
 
-![plot of chunk sf](images/gallery-array-sf-1.png)
+![](images/gallery-array-sf-1.png)
 
 ## `geom_tile_pattern()`
 
@@ -608,7 +578,7 @@ p
 }
 ```
 
-![plot of chunk tile](images/gallery-array-tile-1.png)
+![](images/gallery-array-tile-1.png)
 
 ## `geom_violin_pattern()`
 
@@ -638,4 +608,4 @@ p
 }
 ```
 
-![plot of chunk violin](images/gallery-array-violin-1.png)
+![](images/gallery-array-violin-1.png)

--- a/vignettes/geom-gallery-array.Rmd.orig
+++ b/vignettes/geom-gallery-array.Rmd.orig
@@ -19,44 +19,43 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("dplyr", quietly = TRUE)
+  require("magick", quietly = TRUE)
+  require("maps", quietly = TRUE)
+  require("sf", quietly = TRUE)
 })
 ```
 
 ## `geom_bar_pattern()`
 
-```{r bar}
+```{r bar, fig.cap=""}
 if (require("magick")) {
-
 p <- ggplot(mpg, aes(class)) +
   geom_bar_pattern(
     aes(
-      pattern_angle = class
+      pattern_fill = class
     ), 
-    pattern         = 'placeholder',
-    pattern_type    = 'kitten',
-    fill            = 'white', 
+    pattern         = 'plasma',
     colour          = 'black',
-    pattern_spacing = 0.025
   ) +
   theme_bw(18) +
   labs(
     title = "ggpattern::geom_bar_pattern()",
-    subtitle = "pattern = 'placeholder', pattern_type = 'kitten'"
+    subtitle = "pattern = 'plasma'"
   ) + 
   theme(legend.position = 'none') +
   coord_fixed(ratio = 1/15) + 
   scale_pattern_discrete(guide = guide_legend(nrow = 1))
 
 p
-
 }
 ```
 
 ## `geom_bar_pattern()` - fit image to width and tile.
 
-```{r bar2}
+```{r bar2, fig.cap=""}
 if (require("magick")) {
 
 flags <- c(
@@ -98,7 +97,7 @@ p
 
 ## `geom_bar_pattern()` + `coord_flip` and fit image to height and graivty towards the east.
 
-```{r bar3}
+```{r bar3, fig.cap=""}
 if (require("magick")) {
 
 p <- ggplot(mpg, aes(class)) +
@@ -133,7 +132,7 @@ p
 
 * See `gridpattern::names_magick` for a list of all image based patterns from `imagemagick`
 
-```{r pie}
+```{r pie, fig.cap=""}
 if (require("magick")) {
 
 df <- data.frame(
@@ -171,20 +170,20 @@ p
 
 ## `geom_bin2d_pattern()`
 
-```{r bin2d}
+```{r bin2d, fig.cap=""}
 if (require("magick")) {
 
 p <- ggplot(diamonds, aes(x, y)) + 
   xlim(4, 10) + ylim(4, 10) +
   geom_bin2d_pattern(
-    aes(pattern_type = ..density..), 
+    aes(pattern_type = after_stat(density)), 
     pattern       = 'magick',
     pattern_scale = 3,
     pattern_fill  = 'black',
     bins          = 6, 
     fill          = 'white', 
     colour        = 'black', 
-    size          = 0.5
+    linewidth     = 0.5
   ) +
   theme_bw(18) +
   theme(legend.position = 'none') + 
@@ -200,7 +199,7 @@ p
 ```
 ## `geom_boxplot_pattern()`
 
-```{r boxplot}
+```{r boxplot, fig.cap=""}
 if (require("magick")) {
 
 standard_image_filenames <- c(
@@ -237,10 +236,8 @@ p
 
 ## `geom_col_pattern()`
 
-```{r col}
+```{r col, fig.cap=""}
 if (require("magick")) {
-try({
-
 df <- data.frame(trt = c("a", "b", "c"), outcome = c(2.3, 1.9, 3.2))
 
 p <- ggplot(df, aes(trt, outcome)) +
@@ -258,15 +255,12 @@ p <- ggplot(df, aes(trt, outcome)) +
   coord_fixed(ratio = 1/2)
 
 p
-
-})
-invisible(NULL)
 }
 ```
 
 ## `geom_crossbar_pattern()`
 
-```{r crossbar}
+```{r crossbar, fig.cap=""}
 if (require("magick")) {
 
 df <- data.frame(
@@ -302,7 +296,7 @@ p
 
 ## `geom_density_pattern()`
 
-```{r density}
+```{r density, fig.cap=""}
 if (require("magick")) {
 
 seamless_image_filenames <- c(
@@ -336,7 +330,7 @@ p
 
 ## `geom_map_pattern()`
 
-```{r map, fig.width=12, fig.height=9}
+```{r map, fig.width=12, fig.height=9, fig.cap=""}
 if (require("magick") && require("maps")) {
 
 crimes <- data.frame(state = tolower(rownames(USArrests)), USArrests)
@@ -373,7 +367,7 @@ p
 
 ## `geom_polygon_pattern()`
 
-```{r polygon}
+```{r polygon, fig.cap=""}
 if (require("magick")) {
 
 angle <- seq(0, 2*pi, length.out = 7) + pi/6
@@ -403,7 +397,7 @@ p
 
 ## `geom_rect_pattern()`
 
-```{r rect}
+```{r rect, fig.cap=""}
 if (require("magick")) {
 
 plot_df <- data.frame(
@@ -445,7 +439,7 @@ p
 
 ## `geom_ribbon_pattern()`
 
-```{r ribbon, warning=FALSE}
+```{r ribbon, warning=FALSE, fig.cap=""}
 if (require("magick")) {
 
 huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
@@ -476,7 +470,7 @@ p
 
 ## `geom_sf_pattern()`
 
-```{r sf}
+```{r sf, fig.cap="", warning=FALSE}
 if (require("dplyr") && require("magick") && require("sf")) {
 
 nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
@@ -494,9 +488,7 @@ p <- ggplot(nc) +
     pattern_aspect_ratio = 3
   ) +
   theme_bw(15) + 
-  # theme(legend.key.size = unit(1.5, 'cm')) +
   theme(legend.position = 'none') +
-  scale_pattern_type_discrete(choices = gridpattern::names_magick) + 
   labs(
     title = "ggpattern::geom_sf_pattern()",
     subtitle = "pattern = 'placeholder', pattern_type = 'keanu'"
@@ -509,7 +501,7 @@ p
 
 ## `geom_tile_pattern()`
 
-```{r tile}
+```{r tile, fig.cap=""}
 if (require("magick")) {
 
 df <- data.frame(
@@ -551,7 +543,7 @@ p
 
 ## `geom_violin_pattern()`
 
-```{r violin}
+```{r violin, fig.cap=""}
 if (require("magick")) {
 
 p <- ggplot(mtcars, aes(as.factor(cyl), mpg)) +

--- a/vignettes/geom-gallery-geometry.Rmd
+++ b/vignettes/geom-gallery-geometry.Rmd
@@ -12,8 +12,11 @@ vignette: >
 
 ```r
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("dplyr", quietly = TRUE)
+  require("maps", quietly = TRUE)
+  require("sf", quietly = TRUE)
 })
 ```
 
@@ -44,7 +47,7 @@ p <- ggplot(df, aes(level, outcome)) +
 p
 ```
 
-![plot of chunk bar-bw](images/gallery-geometry-bar-bw-1.png)
+![](images/gallery-geometry-bar-bw-1.png)
 
 ## Colour Example
 
@@ -68,7 +71,7 @@ p <- ggplot(df, aes(level, outcome)) +
 p
 ```
 
-![plot of chunk bar-colour](images/gallery-geometry-bar-colour-1.png)
+![](images/gallery-geometry-bar-colour-1.png)
 
 ## `geom_bar_pattern()`
 
@@ -93,7 +96,7 @@ p <- ggplot(mpg, aes(class)) +
 p
 ```
 
-![plot of chunk bar](images/gallery-geometry-bar-1.png)
+![](images/gallery-geometry-bar-1.png)
 
 ## pie graph with `geom_bar_pattern()`
 
@@ -123,7 +126,7 @@ p <- ggplot(df, aes(x="", y = value, pattern = group, pattern_angle = group))+
 p
 ```
 
-![plot of chunk pie](images/gallery-geometry-pie-1.png)
+![](images/gallery-geometry-pie-1.png)
 
 ## `geom_bin2d_pattern()`
 
@@ -131,16 +134,19 @@ p
 ```r
 p <- ggplot(diamonds, aes(x, y)) + 
   xlim(4, 10) + ylim(4, 10) +
-  geom_bin2d_pattern(aes(pattern_spacing = ..density..), fill = 'white', bins = 6, colour = 'black', size = 1) +
+  geom_bin2d_pattern(aes(pattern_spacing = after_stat(density)), 
+                     fill = 'white', bins = 6, 
+                     colour = 'black', linewidth = 1) +
   theme_bw(18) +
   theme(legend.position = 'none') + 
   labs(title = "ggpattern::geom_bin2d_pattern()")
 
 p
-#> Warning: Removed 478 rows containing non-finite values (stat_bin2d).
+#> Warning: Removed 478 rows containing non-finite outside the scale range
+#> (`stat_bin2d()`).
 ```
 
-![plot of chunk bin2d](images/gallery-geometry-bin2d-1.png)
+![](images/gallery-geometry-bin2d-1.png)
 
 ## `geom_boxplot_pattern()`
 
@@ -162,7 +168,7 @@ p <- ggplot(mpg, aes(class, hwy)) +
 p
 ```
 
-![plot of chunk boxplot](images/gallery-geometry-boxplot-1.png)
+![](images/gallery-geometry-boxplot-1.png)
 
 ## `geom_col_pattern()`
 
@@ -188,7 +194,7 @@ p <- ggplot(df, aes(trt, outcome)) +
 p
 ```
 
-![plot of chunk col](images/gallery-geometry-col-1.png)
+![](images/gallery-geometry-col-1.png)
 
 ## `geom_crossbar_pattern()`
 
@@ -220,7 +226,7 @@ p <- ggplot(df, aes(trt, resp, colour = group)) +
 p
 ```
 
-![plot of chunk crossbar](images/gallery-geometry-crossbar-1.png)
+![](images/gallery-geometry-crossbar-1.png)
 
 ## `geom_density_pattern()`
 
@@ -245,13 +251,13 @@ p <- ggplot(mtcars) +
 p
 ```
 
-![plot of chunk density](images/gallery-geometry-density-1.png)
+![](images/gallery-geometry-density-1.png)
 
 ## `geom_map_pattern()`
 
 
 ```r
-if (require(maps)) {
+if (require("maps")) {
 
 crimes <- data.frame(state = tolower(rownames(USArrests)), USArrests)
 
@@ -285,7 +291,7 @@ p
 }
 ```
 
-![plot of chunk map](images/gallery-geometry-map-1.png)
+![](images/gallery-geometry-map-1.png)
 
 ## `geom_polygon_pattern()`
 
@@ -317,7 +323,7 @@ p <- ggplot(polygon_df) +
 p
 ```
 
-![plot of chunk polygon](images/gallery-geometry-polygon-1.png)
+![](images/gallery-geometry-polygon-1.png)
 
 ## `geom_rect_pattern()`
 
@@ -358,7 +364,7 @@ p <- ggplot(plot_df) +
 p
 ```
 
-![plot of chunk rect](images/gallery-geometry-rect-1.png)
+![](images/gallery-geometry-rect-1.png)
 ## `geom_ribbon_pattern()`
 
 
@@ -385,7 +391,7 @@ p <- ggplot(huron, aes(year)) +
 p
 ```
 
-![plot of chunk ribbon](images/gallery-geometry-ribbon-1.png)
+![](images/gallery-geometry-ribbon-1.png)
 ## `geom_sf_pattern()`
 
 
@@ -412,7 +418,7 @@ p
 }
 ```
 
-![plot of chunk sf](images/gallery-geometry-sf-1.png)
+![](images/gallery-geometry-sf-1.png)
 
 ## `geom_tile_pattern()`
 
@@ -444,7 +450,7 @@ p <- ggplot(df, aes(x, y)) +
 p
 ```
 
-![plot of chunk tile](images/gallery-geometry-tile-1.png)
+![](images/gallery-geometry-tile-1.png)
 
 ## `geom_violin_pattern()`
 
@@ -462,4 +468,4 @@ p <- ggplot(mtcars, aes(as.factor(cyl), mpg)) +
 p
 ```
 
-![plot of chunk violin](images/gallery-geometry-violin-1.png)
+![](images/gallery-geometry-violin-1.png)

--- a/vignettes/geom-gallery-geometry.Rmd.orig
+++ b/vignettes/geom-gallery-geometry.Rmd.orig
@@ -20,14 +20,17 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("dplyr", quietly = TRUE)
+  require("maps", quietly = TRUE)
+  require("sf", quietly = TRUE)
 })
 ```
 
 ## B&W Example
 
-```{r bar-bw, fig.width = 12, fig.height = 9}
+```{r bar-bw, fig.width = 12, fig.height = 9, fig.cap=""}
 df <- data.frame(level = c("a", "b", "c", 'd'), outcome = c(2.3, 1.9, 3.2, 1))
 
 p <- ggplot(df, aes(level, outcome)) +
@@ -53,7 +56,7 @@ p
 
 ## Colour Example
 
-```{r bar-colour, fig.width = 12, fig.height = 9}
+```{r bar-colour, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(df, aes(level, outcome)) +
   geom_col_pattern(
     aes(pattern = level, fill = level, pattern_fill = level), 
@@ -74,7 +77,7 @@ p
 
 ## `geom_bar_pattern()`
 
-```{r bar, fig.width = 12, fig.height = 9}
+```{r bar, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(mpg, aes(class)) +
   geom_bar_pattern(
     aes(
@@ -96,7 +99,7 @@ p
 
 ## pie graph with `geom_bar_pattern()`
 
-```{r pie, fig.width = 12, fig.height = 9}
+```{r pie, fig.width = 12, fig.height = 9, fig.cap=""}
 df <- data.frame(
   group = factor(c("Cool", "But", "Use", "Less"), levels = c("Cool", "But", "Use", "Less")),
   value = c(10, 20, 30, 40)
@@ -123,10 +126,12 @@ p
 
 ## `geom_bin2d_pattern()`
 
-```{r bin2d, fig.width = 12, fig.height = 9}
+```{r bin2d, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(diamonds, aes(x, y)) + 
   xlim(4, 10) + ylim(4, 10) +
-  geom_bin2d_pattern(aes(pattern_spacing = ..density..), fill = 'white', bins = 6, colour = 'black', size = 1) +
+  geom_bin2d_pattern(aes(pattern_spacing = after_stat(density)), 
+                     fill = 'white', bins = 6, 
+                     colour = 'black', linewidth = 1) +
   theme_bw(18) +
   theme(legend.position = 'none') + 
   labs(title = "ggpattern::geom_bin2d_pattern()")
@@ -136,7 +141,7 @@ p
 
 ## `geom_boxplot_pattern()`
 
-```{r boxplot, fig.width = 12, fig.height = 9}
+```{r boxplot, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(mpg, aes(class, hwy)) +
   geom_boxplot_pattern(
     aes(
@@ -155,7 +160,7 @@ p
 
 ## `geom_col_pattern()`
 
-```{r col, fig.width = 12, fig.height = 9}
+```{r col, fig.width = 12, fig.height = 9, fig.cap=""}
 df <- data.frame(trt = c("a", "b", "c"), outcome = c(2.3, 1.9, 3.2))
 
 p <- ggplot(df, aes(trt, outcome)) +
@@ -178,7 +183,7 @@ p
 
 ## `geom_crossbar_pattern()`
 
-```{r crossbar, fig.width = 12, fig.height = 9}
+```{r crossbar, fig.width = 12, fig.height = 9, fig.cap=""}
 df <- data.frame(
   trt = factor(c(1, 1, 2, 2)),
   resp = c(1, 5, 3, 4),
@@ -207,7 +212,7 @@ p
 
 ## `geom_density_pattern()`
 
-```{r density, fig.width = 12, fig.height = 9}
+```{r density, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(mtcars) +
    geom_density_pattern(
      aes(
@@ -229,8 +234,8 @@ p
 
 ## `geom_map_pattern()`
 
-```{r map, fig.width = 12, fig.height = 9}
-if (require(maps)) {
+```{r map, fig.width = 12, fig.height = 9, fig.cap=""}
+if (require("maps")) {
 
 crimes <- data.frame(state = tolower(rownames(USArrests)), USArrests)
 
@@ -266,7 +271,7 @@ p
 
 ## `geom_polygon_pattern()`
 
-```{r polygon, fig.width = 12, fig.height = 9}
+```{r polygon, fig.width = 12, fig.height = 9, fig.cap=""}
 angle <- seq(0, 2*pi, length.out = 7) + pi/6
 polygon_df <- data.frame(
   angle = angle,
@@ -295,7 +300,7 @@ p
 
 ## `geom_rect_pattern()`
 
-```{r rect, fig.width = 12, fig.height = 9}
+```{r rect, fig.width = 12, fig.height = 9, fig.cap=""}
 plot_df <- data.frame(
   xmin    = c(0, 10),
   xmax    = c(8, 18),
@@ -332,7 +337,7 @@ p
 ```
 ## `geom_ribbon_pattern()`
 
-```{r ribbon, fig.width = 12, fig.height = 9, warning=FALSE}
+```{r ribbon, fig.width = 12, fig.height = 9, warning=FALSE, fig.cap=""}
 huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
 
 p <- ggplot(huron, aes(year)) +
@@ -356,7 +361,7 @@ p
 ```
 ## `geom_sf_pattern()`
 
-```{r sf, fig.width = 12, fig.height = 9}
+```{r sf, fig.width = 12, fig.height = 9, fig.cap=""}
 if (require("dplyr") && require("sf")) {
 
 nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
@@ -381,7 +386,7 @@ p
 
 ## `geom_tile_pattern()`
 
-```{r tile, fig.width = 12, fig.height = 9}
+```{r tile, fig.width = 12, fig.height = 9, fig.cap=""}
 df <- data.frame(
   x = rep(c(2, 5, 7, 9, 12), 2),
   y = rep(c(1, 2), each = 5),
@@ -410,7 +415,7 @@ p
 
 ## `geom_violin_pattern()`
 
-```{r violin, fig.width = 12, fig.height = 9}
+```{r violin, fig.width = 12, fig.height = 9, fig.cap=""}
 p <- ggplot(mtcars, aes(as.factor(cyl), mpg)) +
   geom_violin_pattern(aes(pattern = as.factor(cyl))) +
   theme_bw(18) +

--- a/vignettes/gganimate.Rmd
+++ b/vignettes/gganimate.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
   fig.width = 6,
   fig.height = 4
 )
+require("gganimate", quietly = TRUE)
 ```
 
 
@@ -58,13 +59,8 @@ p <- ggplot(df, aes(trt, outcome)) +
 p <- p + transition_states(time, transition_length = 2,
                     state_length = 0, wrap = FALSE)
 
-animate(p, nframes = 60, fps = 20)
-
+anim_save("images/gganimate.gif", p, nframes = 60, fps = 20)
 }
 ```
 
-Future
-------------------------------------------------------------------------------
-
-* Include more examples
-
+<img src="images/gganimate.gif" alt="ggpattern + gganimate">

--- a/vignettes/patterns-image.Rmd
+++ b/vignettes/patterns-image.Rmd
@@ -12,8 +12,9 @@ vignette: >
 
 ```r
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("magick", quietly = TRUE)
 })
 ```
 
@@ -99,6 +100,7 @@ df1 <- data.frame(
 ```
 
 
+
 Table: Example Data
 
 |trt | outcome|gravity |filltype | scale|filename                                               |
@@ -106,6 +108,8 @@ Table: Example Data
 |a   |     2.3|South   |squish   |   1.0|/usr/local/lib/R/site-library/png/img/Rlogo.png        |
 |b   |     1.9|North   |fit      |   2.0|/usr/local/lib/R/site-library/ggpattern/img/magpie.jpg |
 |c   |     3.2|West    |expand   |   0.5|/usr/local/lib/R/site-library/ggpattern/img/bug.jpg    |
+
+
 
 ### Example: `pattern = 'image'` - No Attempt at filling the area (`pattern_type = 'none'`)
 
@@ -140,7 +144,7 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk none](images/patterns-image-none-1.png)
+![](images/patterns-image-none-1.png)
 
 ### Example: `pattern = 'image'` - Covering the area (`pattern_type = 'fit', 'squish', 'expand'`)
 
@@ -182,7 +186,7 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk covering](images/patterns-image-covering-1.png)
+![](images/patterns-image-covering-1.png)
 
 ### Example: `pattern = 'image'` - Tiling (`pattern_type = 'tile'`)
 
@@ -219,7 +223,7 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk tiling](images/patterns-image-tiling-1.png)
+![](images/patterns-image-tiling-1.png)
 
 ### Example: `pattern = 'image'` - Tiling with seamless patterns
 
@@ -250,7 +254,7 @@ ggplot(mtcars) +
 }
 ```
 
-![plot of chunk tiling-seamless](images/patterns-image-tiling-seamless-1.png)
+![](images/patterns-image-tiling-seamless-1.png)
 
 ### Example: `pattern = 'image'` - Tiling with seamless patterns (with scaling)
 
@@ -280,7 +284,7 @@ ggplot(mtcars) +
 }
 ```
 
-![plot of chunk tiling-seamless-scaling](images/patterns-image-tiling-seamless-scaling-1.png)
+![](images/patterns-image-tiling-seamless-scaling-1.png)
 
 ### Example: `pattern = 'image'` - Tiling with fit to width (of element bounding box)
 
@@ -318,7 +322,7 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk tiling-fit](images/patterns-image-tiling-fit-1.png)
+![](images/patterns-image-tiling-fit-1.png)
 
 ## `placeholder` - Filling with an image placeholder
 
@@ -404,7 +408,7 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk bear](images/patterns-image-bear-1.png)
+![](images/patterns-image-bear-1.png)
 
 ### Example: `pattern = 'placeholder'` - `pattern_type = 'picsum'`  
 
@@ -429,7 +433,7 @@ ggplot(mtcars) +
 }
 ```
 
-![plot of chunk picsum](images/patterns-image-picsum-1.png)
+![](images/patterns-image-picsum-1.png)
 
 ### Example: `pattern = 'placeholder'` - `pattern_type = 'dummy'` 
 
@@ -455,46 +459,12 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-![plot of chunk dummy](images/patterns-image-dummy-1.png)
-
-### Example: `pattern = 'placeholder'` - `pattern_type = 'kitten'` 
-
-
-```r
-if (require("magick")) {
-
-df2 <- data.frame(
-  group = factor(c("Cool", "But", "Use", "Less"), levels = c("Cool", "But", "Use", "Less")),
-  value = c(10, 20, 30, 40)
-)
-
-ggplot(df2, aes(x="", y = value, pattern_angle = group))+
-  geom_bar_pattern(
-    pattern      = 'placeholder',
-    pattern_type = 'kitten',
-    pattern_aspect_ratio = 1,
-    width        = 1,
-    stat         = "identity",
-    colour       = 'white',
-    size         = 2
-  ) +
-  coord_polar("y", start=0) +
-  theme_void(15) +
-  theme(legend.position = 'none') +
-  labs(
-    title    = "ggpattern::geom_col_pattern()",
-    subtitle = "pattern='placeholder', pattern_type='kitten'"
-  ) 
-
-}
-```
-
-![plot of chunk kitten](images/patterns-image-kitten-1.png)
+![](images/patterns-image-dummy-1.png)
 
 ## Resetting the image cache
 
 `{gridpattern}` stores the images used by the `"image"` and `"placeholder"` patterns in a cache.
 This is mainly to avoid the risk of re-downloading the same image over and over especially for
 the `"placeholder"` pattern.  However, this may cause [problems if you re-using the same image filename
-but the images in those files are changing](https://github.com/coolbutuseless/ggpattern/issues/95).
+but the images in those files are changing](https://github.com/trevorld/ggpattern/issues/95).
 You may reset this image cache with `gridpattern::reset_image_cache()`.

--- a/vignettes/patterns-image.Rmd.orig
+++ b/vignettes/patterns-image.Rmd.orig
@@ -20,8 +20,9 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("magick", quietly = TRUE)
 })
 ```
 
@@ -115,7 +116,7 @@ If `pattern_type = 'none'` then no attempt is made at snugly filling the area.
 Instead a single copy of the image is scaled (`pattern_scale`) and 
 placed (`pattern_gravity`) in the geom area.
 
-```{r none}
+```{r none, fig.cap=""}
 if (require("magick")) {
 
 ggplot(df1, aes(trt, outcome)) +
@@ -153,7 +154,7 @@ left-to-right:
   that the entire geom is covered.  `pattern_gravity = 'West'` anchors the image
   to the left side of the geom.
 
-```{r covering}
+```{r covering, fig.cap=""}
 if (require("magick")) {
 
 ggplot(df1, aes(trt, outcome)) +
@@ -187,7 +188,7 @@ In this example, `pattern_scale` is also applied to the image so that it appears
 different sizes.
 
 
-```{r tiling}
+```{r tiling, fig.cap=""}
 if (require("magick")) {
 
 ggplot(df1, aes(trt, outcome)) +
@@ -218,7 +219,7 @@ ggplot(df1, aes(trt, outcome)) +
 
 By choosing a seamlessly tiling image, then a tiled fill will not have visible discontinuities.
 
-```{r tiling-seamless}
+```{r tiling-seamless, fig.cap=""}
 if (require("magick")) {
 
 ggplot(mtcars) +
@@ -244,7 +245,7 @@ ggplot(mtcars) +
 
 ### Example: `pattern = 'image'` - Tiling with seamless patterns (with scaling)
 
-```{r tiling-seamless-scaling}
+```{r tiling-seamless-scaling, fig.cap=""}
 if (require("magick")) {
 
 ggplot(mtcars) +
@@ -278,7 +279,7 @@ This is useful for bar charts.
 Specify `pattern_scale = -1` to fit the width of the geom, and `pattern_scale = -2` to 
 fit the height of the geom.
 
-```{r tiling-fit}
+```{r tiling-fit, fig.cap=""}
 if (require("magick")) {
 
 ggplot(df1, aes(trt, outcome)) +
@@ -365,7 +366,7 @@ df1 <- data.frame(
 
 ### Example: `pattern = 'placeholder'` - `pattern_type = 'bear'` 
 
-```{r bear}
+```{r bear, fig.cap=""}
 if (require("magick")) { 
 
 ggplot(df1, aes(trt, outcome)) +
@@ -388,7 +389,7 @@ ggplot(df1, aes(trt, outcome)) +
 
 ### Example: `pattern = 'placeholder'` - `pattern_type = 'picsum'`  
 
-```{r picsum}
+```{r picsum, fig.cap=""}
 if (require("magick")) {
 
 ggplot(mtcars) +
@@ -410,7 +411,7 @@ ggplot(mtcars) +
 
 ### Example: `pattern = 'placeholder'` - `pattern_type = 'dummy'` 
 
-```{r dummy}
+```{r dummy, fig.cap=""}
 if (require("magick")) {
 
 ggplot(df1, aes(trt, outcome)) +
@@ -431,41 +432,10 @@ ggplot(df1, aes(trt, outcome)) +
 }
 ```
 
-### Example: `pattern = 'placeholder'` - `pattern_type = 'kitten'` 
-
-```{r kitten}
-if (require("magick")) {
-
-df2 <- data.frame(
-  group = factor(c("Cool", "But", "Use", "Less"), levels = c("Cool", "But", "Use", "Less")),
-  value = c(10, 20, 30, 40)
-)
-
-ggplot(df2, aes(x="", y = value, pattern_angle = group))+
-  geom_bar_pattern(
-    pattern      = 'placeholder',
-    pattern_type = 'kitten',
-    pattern_aspect_ratio = 1,
-    width        = 1,
-    stat         = "identity",
-    colour       = 'white',
-    size         = 2
-  ) +
-  coord_polar("y", start=0) +
-  theme_void(15) +
-  theme(legend.position = 'none') +
-  labs(
-    title    = "ggpattern::geom_col_pattern()",
-    subtitle = "pattern='placeholder', pattern_type='kitten'"
-  ) 
-
-}
-```
-
 ## Resetting the image cache
 
 `{gridpattern}` stores the images used by the `"image"` and `"placeholder"` patterns in a cache.
 This is mainly to avoid the risk of re-downloading the same image over and over especially for
 the `"placeholder"` pattern.  However, this may cause [problems if you re-using the same image filename
-but the images in those files are changing](https://github.com/coolbutuseless/ggpattern/issues/95).
+but the images in those files are changing](https://github.com/trevorld/ggpattern/issues/95).
 You may reset this image cache with `gridpattern::reset_image_cache()`.

--- a/vignettes/patterns-noise.Rmd
+++ b/vignettes/patterns-noise.Rmd
@@ -19,8 +19,9 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 suppressPackageStartupMessages({
-  library(ggplot2)
-  library(ggpattern)
+  library("ggplot2")
+  library("ggpattern")
+  require("magick", quietly = TRUE)
 })
 ```
 

--- a/vignettes/precompute_vignettes.R
+++ b/vignettes/precompute_vignettes.R
@@ -1,0 +1,6 @@
+should_cd <- basename(getwd()) != "vignettes"
+if (should_cd) setwd("vignettes")
+knitr::knit("geom-gallery-array.Rmd.orig", "geom-gallery-array.Rmd")
+knitr::knit("geom-gallery-geometry.Rmd.orig", "geom-gallery-geometry.Rmd")
+knitr::knit("patterns-image.Rmd.orig", "patterns-image.Rmd")
+if (should_cd) setwd("..")


### PR DESCRIPTION
* In `gganimate.Rmd` we now save {gganimate} animation with `gganimate::anim_save()` instead of trying to save and view animation with {knitr} hook. This avoids an error due to an upstream bug.
* Add `vignettes/precompute_vignettes.R` to version control

progress on #114
closes #108