### PR TITLE
Use `png(type="cairo")` in vignette example to avoid UBSAN warning on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggpattern
 Type: Package
 Title: 'ggplot2' Pattern Geoms
-Version: 1.1.3
+Version: 1.1.4-0
 Authors@R: c(person("Mike", "FC", role = "aut"),
              person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# ggpattern 1.1.4
+
+## Bug fixes and minor improvements
+
+* Updated a couple of examples to use the `linewidth` aesthetic
+  instead of the `size` aesthetic which was deprecated in `{ggplot2}` 3.4.0.
+
 # ggpattern 1.1.3
 
 ## Bug fixes and minor improvements

--- a/R/scale-pattern-alpha.R
+++ b/R/scale-pattern-alpha.R
@@ -20,7 +20,7 @@
 #'         pattern = 'stripe',
 #'         fill    = 'white',
 #'         colour  = 'black',
-#'         size = 1.5
+#'         linewidth = 1.5
 #'       ) +
 #'       theme_bw(18) +
 #'       theme(legend.position = 'none') +

--- a/R/scale-pattern-linetype.R
+++ b/R/scale-pattern-linetype.R
@@ -20,7 +20,7 @@
 #'         pattern = 'stripe',
 #'         fill    = 'white',
 #'         colour  = 'black',
-#'         size = 1.5
+#'         linewidth = 1.5
 #'       ) +
 #'       theme_bw(18) +
 #'       theme(legend.position = 'none') +

--- a/R/scale-pattern-size.R
+++ b/R/scale-pattern-size.R
@@ -12,7 +12,7 @@
 #'     gg <- ggplot(df) +
 #'       geom_col_pattern(
 #'         aes(level, outcome, pattern_fill = level,
-#'             size = outcome, pattern_size = outcome),
+#'             linewidth = outcome, pattern_size = outcome),
 #'         pattern_density = 0.4,
 #'         pattern_spacing = 0.3,
 #'         pattern = 'circle',

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,9 @@
-Added missing package anchors to a few Rd cross-references.
-These should eliminate the "Rd cross-references" check NOTEs on CRAN.
+In `vignettes/patterns-noise.Rmd` we now save images with
+`png(type="cairo")` instead of `ragg::agg_png()` which should
+prevent any UBSAN warnings occurring on CRAN checks
 
 In order to keep the package tarball
-under 5 MB we omit the package (visual) unit tests 
+under 5 MB we omit the package (visual) unit tests
 and we omit seven package vignettes.
 
 ## Test environments

--- a/man/scale_pattern_alpha_continuous.Rd
+++ b/man/scale_pattern_alpha_continuous.Rd
@@ -40,7 +40,7 @@ See \code{\link[ggplot2:scale_alpha]{ggplot2::scale_alpha()}} for details.
         pattern = 'stripe',
         fill    = 'white',
         colour  = 'black',
-        size = 1.5
+        linewidth = 1.5
       ) +
       theme_bw(18) +
       theme(legend.position = 'none') +

--- a/man/scale_pattern_linetype.Rd
+++ b/man/scale_pattern_linetype.Rd
@@ -37,7 +37,7 @@ line types.
         pattern = 'stripe',
         fill    = 'white',
         colour  = 'black',
-        size = 1.5
+        linewidth = 1.5
       ) +
       theme_bw(18) +
       theme(legend.position = 'none') +

--- a/man/scale_pattern_size_continuous.Rd
+++ b/man/scale_pattern_size_continuous.Rd
@@ -50,7 +50,7 @@ Scales for area or radius
     gg <- ggplot(df) +
       geom_col_pattern(
         aes(level, outcome, pattern_fill = level,
-            size = outcome, pattern_size = outcome),
+            linewidth = outcome, pattern_size = outcome),
         pattern_density = 0.4,
         pattern_spacing = 0.3,
         pattern = 'circle',

--- a/vignettes/patterns-noise.Rmd
+++ b/vignettes/patterns-noise.Rmd
@@ -15,6 +15,15 @@ knitr::opts_chunk$set(
   fig.width = 8,
   fig.height = 6
 )
+
+# Can't use {ragg} to save gradient example on CRAN due to UBSAN issue
+if (!identical(Sys.getenv("IN_PKGDOWN"), "true")) {
+  knitr::opts_chunk$set(
+    dev = "png",
+    dev.args = list(type = "cairo"),
+    eval = all(capabilities(c("png", "cairo")))
+  )
+}
 ```
 
 ```{r setup}
@@ -31,11 +40,11 @@ suppressPackageStartupMessages({
   This pattern either depends on the R package `{magick}`
   or a graphics device and version of R that supports the
   new R 4.1 gradient feature.
-* The 'plasma' pattern uses Imagemagick (`magick`) to generate some 
+* The 'plasma' pattern uses Imagemagick (`magick`) to generate some
   fractal noise arrays which are coloured and used to fill the geom.
   This pattern depends on the R package `{magick}`.
-* The `{ambient}` package offers a way of creating multiple different types of 
-  noise as a matrix of values.  The 'ambient' pattern maps this noise 
+* The `{ambient}` package offers a way of creating multiple different types of
+  noise as a matrix of values.  The 'ambient' pattern maps this noise
   to a colour gradient between two user-specified colours.
 * For more info on these patterns see their `{gridpattern}` documentation:
 
@@ -60,7 +69,7 @@ suppressPackageStartupMessages({
 
 ```{r}
 df <- data.frame(
-  trt     = c("a", "b", "c"), 
+  trt     = c("a", "b", "c"),
   outcome = c(2.3, 1.9, 3.2)
 )
 ```
@@ -125,9 +134,9 @@ ggplot(df, aes(trt, outcome)) +
     aes(
       pattern_fill        = trt,
       pattern_orientation = trt
-    ), 
-    pattern       = 'gradient', 
-    pattern_fill2 = 'white', 
+    ),
+    pattern       = 'gradient',
+    pattern_fill2 = 'white',
     colour        = 'black'
   ) +
   theme_bw(15) +
@@ -154,9 +163,9 @@ ggplot(df, aes(trt, outcome)) +
     aes(
       pattern_fill        = trt,
       pattern_orientation = trt
-    ), 
-    pattern       = 'gradient', 
-    pattern_fill2 = '#445566', 
+    ),
+    pattern       = 'gradient',
+    pattern_fill2 = '#445566',
     colour        = 'black'
   ) +
   theme_bw(15) +
@@ -183,9 +192,9 @@ ggplot(df, aes(trt, outcome)) +
     aes(
       pattern_fill        = trt,
       pattern_orientation = trt
-    ), 
-    pattern       = 'gradient', 
-    pattern_fill2 = NA, 
+    ),
+    pattern       = 'gradient',
+    pattern_fill2 = NA,
     fill          = NA,
     colour        = 'black'
   ) +
@@ -207,12 +216,12 @@ if (require("magick")) {
 ggplot(mtcars) +
   geom_density_pattern(
     aes(
-      x = mpg, 
+      x = mpg,
       pattern_fill = as.factor(cyl),
       pattern_orientation = as.factor(cyl)
-    ), 
+    ),
     pattern       = 'gradient',
-    pattern_fill2 = NA, 
+    pattern_fill2 = NA,
     fill          = NA
   ) +
   theme_bw(15) +
@@ -232,9 +241,9 @@ if (require("ambient")) {
 ggplot(df, aes(trt, outcome)) +
   geom_col_pattern(
     aes(pattern_fill = trt),
-    pattern       = 'ambient', 
+    pattern       = 'ambient',
     pattern_fill2 = 'white',
-    colour        = NA, 
+    colour        = NA,
     fill          = NA
   ) +
   theme_bw(15) +
@@ -251,19 +260,19 @@ if (require("ambient")) {
 ggplot(mtcars) +
   geom_density_pattern(
     aes(
-      x = mpg, 
-      pattern_fill  = as.factor(cyl), 
+      x = mpg,
+      pattern_fill  = as.factor(cyl),
       pattern_fill2 = as.factor(cyl)
-    ), 
+    ),
     pattern = 'ambient'
   ) +
   theme_bw(15) +
-  theme(legend.key.size = unit(2, 'cm')) + 
-  scale_pattern_fill_brewer (palette = 'Accent', direction =  1) + 
-  scale_pattern_fill2_brewer(palette = 'Dark2' , direction =  1) + 
+  theme(legend.key.size = unit(2, 'cm')) +
+  scale_pattern_fill_brewer (palette = 'Accent', direction =  1) +
+  scale_pattern_fill2_brewer(palette = 'Dark2' , direction =  1) +
   labs(
     title    = "ggpattern::geom_density_pattern()",
     subtitle = "pattern = 'ambient'"
-  ) 
+  )
 }
 ```


### PR DESCRIPTION
* In "noise" vignette save images with `png(type="cairo")` to avoid UBSAN warning on CRAN being raised in `{ragg}`
* Tweak examples to use `linewidth` instead of deprecated `size`

closes #131